### PR TITLE
Refine plan block instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ prompt that governs an agent's behaviour.
 The agent will then follow the loop defined in the system prompt until the goal
 is met or it halts with failure.
 
+Each round begins with a short `~PLAN[...]` block summarizing the next step for the user. This plan is purely informational and does not influence the agent's reasoning.
+
 See the prompt file for full syntax and safety rules.
 
 This repository contains the system prompt specification and examples for VantLang – a structured language designed for LLM-native execution and reasoning.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ prompt that governs an agent's behaviour.
 The agent will then follow the loop defined in the system prompt until the goal
 is met or it halts with failure.
 
-Each round begins with a short `~PLAN[...]` block summarizing the next step for the user. This plan is purely informational and does not influence the agent's reasoning.
+Each round begins with a `~PLAN[...]` block containing the agent's internal step breakdown.
+Immediately after, the agent outputs `~BRIEF[...]` to summarize that step for the user. This brief summary does not influence the agent's reasoning.
 
 See the prompt file for full syntax and safety rules.
 

--- a/core/prompt/system.md
+++ b/core/prompt/system.md
@@ -22,7 +22,8 @@ Your job is to:
 
 You MUST ONLY respond using the following valid blocks (case-sensitive):
 
- - `~PLAN[...]`         → brief summary of the next step for the user; do not rely on this for reasoning
+- `~PLAN[...]`         → your high-level thinking and step breakdown for the next step
+- `~BRIEF[...]`        → short summary of that step for the user; do not rely on this for reasoning
 - `>ACT[...]`          → one atomic executable action (e.g., code snippet, command, fetch)  
 - `@STATE[...]`        → result of the previous action, will be fed externally  
 - `~REFLECT[...]`      → reasoning about last outcome, decide next step  
@@ -43,15 +44,17 @@ You MUST ONLY respond using the following valid blocks (case-sensitive):
 
 You will follow this loop strictly:
 
-1. Output `~PLAN[...]` with a short summary for the user (every round)
-2. Output `>ACT[...]` with one action
-3. Wait for the system to provide `@STATE[...]`  
-4. Output `~REFLECT[...]` based on the result  
-5. Repeat step 2 onward  
-6. End with `ΩHALT[...]` (success) or `ΩHALT[FAILED:...]` (failure)
+1. Output `~PLAN[...]` with internal step reasoning (every round)
+2. Output `~BRIEF[...]` with a short summary for the user
+3. Output `>ACT[...]` with one action
+4. Wait for the system to provide `@STATE[...]`
+5. Output `~REFLECT[...]` based on the result
+6. Repeat step 3 onward
+7. End with `ΩHALT[...]` (success) or `ΩHALT[FAILED:...]` (failure)
 
 All reasoning must happen inside `~REFLECT[...]`.
-The `~PLAN` output is only for user visibility and must not alter your internal reasoning.
+`~PLAN` guides your next action internally.
+`~BRIEF` is only for user visibility and must not alter your reasoning.
 All actions must be within `>ACT[...]`.
 No external commentary or explanation is allowed.
 
@@ -65,5 +68,5 @@ No external commentary or explanation is allowed.
 
 ---
 
-Begin processing after the user sends the first input blocks: `!GOAL[...]`, `@ENV[...]`, `ΩHALT[...]`.  
-Then immediately respond with `~PLAN[...]` to begin and repeat this brief plan at the start of every round.
+Begin processing after the user sends the first input blocks: `!GOAL[...]`, `@ENV[...]`, `ΩHALT[...]`.
+Then immediately respond with `~PLAN[...]` and `~BRIEF[...]` to begin and repeat both at the start of every round.

--- a/core/prompt/system.md
+++ b/core/prompt/system.md
@@ -22,7 +22,7 @@ Your job is to:
 
 You MUST ONLY respond using the following valid blocks (case-sensitive):
 
-- `~PLAN[...]`         → your initial high-level thinking and step breakdown  
+ - `~PLAN[...]`         → brief summary of the next step for the user; do not rely on this for reasoning
 - `>ACT[...]`          → one atomic executable action (e.g., code snippet, command, fetch)  
 - `@STATE[...]`        → result of the previous action, will be fed externally  
 - `~REFLECT[...]`      → reasoning about last outcome, decide next step  
@@ -43,14 +43,15 @@ You MUST ONLY respond using the following valid blocks (case-sensitive):
 
 You will follow this loop strictly:
 
-1. Output `~PLAN[...]` with task breakdown  
-2. Output `>ACT[...]` with one action  
+1. Output `~PLAN[...]` with a short summary for the user (every round)
+2. Output `>ACT[...]` with one action
 3. Wait for the system to provide `@STATE[...]`  
 4. Output `~REFLECT[...]` based on the result  
 5. Repeat step 2 onward  
 6. End with `ΩHALT[...]` (success) or `ΩHALT[FAILED:...]` (failure)
 
-All reasoning must happen inside `~REFLECT[...]`.  
+All reasoning must happen inside `~REFLECT[...]`.
+The `~PLAN` output is only for user visibility and must not alter your internal reasoning.
 All actions must be within `>ACT[...]`.
 No external commentary or explanation is allowed.
 
@@ -65,4 +66,4 @@ No external commentary or explanation is allowed.
 ---
 
 Begin processing after the user sends the first input blocks: `!GOAL[...]`, `@ENV[...]`, `ΩHALT[...]`.  
-Then immediately respond with `~PLAN[...]` to begin.
+Then immediately respond with `~PLAN[...]` to begin and repeat this brief plan at the start of every round.


### PR DESCRIPTION
## Summary
- clarify that `~PLAN` is a concise user-facing summary in the prompt
- indicate that `~PLAN` is repeated each round for display only
- note in README how the plan output is informational

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_683fae374bb88324a2f397e961a0c557